### PR TITLE
Feature/snapcast jsonrpc client control

### DIFF
--- a/SnapcastMPRISInterface.py
+++ b/SnapcastMPRISInterface.py
@@ -217,7 +217,7 @@ class SnapcastMPRISInterface(dbus.service.Object):
     @dbus.service.method(PROP_INTERFACE,
                          in_signature="ss", out_signature="v")
     def Get(self, interface, prop):
-        getter, _setter = self.PROP_MAPPING[interface][prop]
+        getter, _setter = self.get_prop_mapping()[interface][prop]
         if callable(getter):
             return getter()
         return getter
@@ -225,7 +225,7 @@ class SnapcastMPRISInterface(dbus.service.Object):
     @dbus.service.method(PROP_INTERFACE,
                          in_signature="ssv", out_signature="")
     def Set(self, interface, prop, value):
-        _getter, setter = self.PROP_MAPPING[interface][prop]
+        _getter, setter = self.get_prop_mapping()[interface][prop]
         if setter is not None:
             setter(value)
 
@@ -233,7 +233,7 @@ class SnapcastMPRISInterface(dbus.service.Object):
                          in_signature="s", out_signature="a{sv}")
     def GetAll(self, interface):
         read_props = {}
-        props = self.PROP_MAPPING[interface]
+        props = self.get_prop_mapping()[interface]
         for key, (getter, _setter) in props.items():
             if callable(getter):
                 getter = getter()
@@ -241,7 +241,7 @@ class SnapcastMPRISInterface(dbus.service.Object):
         return read_props
 
     def update_property(self, interface, prop):
-        getter, _setter = self.PROP_MAPPING[interface][prop]
+        getter, _setter = self.get_prop_mapping()[interface][prop]
         if callable(getter):
             value = getter()
         else:
@@ -255,7 +255,6 @@ class SnapcastMPRISInterface(dbus.service.Object):
     def Pause(self):
         logging.debug("received DBUS pause")
         self.wrapper_instance.pause_playback()
-        return
 
     @dbus.service.method(PLAYER_INTERFACE, in_signature='', out_signature='')
     def PlayPause(self):
@@ -266,15 +265,13 @@ class SnapcastMPRISInterface(dbus.service.Object):
             self.wrapper_instance.pause_playback()
         else:
             self.wrapper_instance.start_playback()
-        return
 
     @dbus.service.method(PLAYER_INTERFACE, in_signature='', out_signature='')
     def Stop(self):
         logging.debug("received DBUS stop")
         self.wrapper_instance.stop_playback()
-        return
 
     @dbus.service.method(PLAYER_INTERFACE, in_signature='', out_signature='')
     def Play(self):
+        logging.debug("received DBUS play")
         self.wrapper_instance.start_playback()
-        return

--- a/SnapcastMPRISInterface.py
+++ b/SnapcastMPRISInterface.py
@@ -1,0 +1,280 @@
+import sys
+import logging
+import time
+import os
+import subprocess
+import json
+import signal
+import dbus.service
+import SnapcastWrapper
+
+
+class SnapcastMPRISInterface(dbus.service.Object):
+    ''' The base object of an MPRIS player '''
+
+    PATH = "/org/mpris/MediaPlayer2"
+    INTROSPECT_INTERFACE = "org.freedesktop.DBus.Introspectable"
+    PROP_INTERFACE = dbus.PROPERTIES_IFACE
+    PLAYER_INTERFACE = "org.mpris.MediaPlayer2.Player"
+    ROOT_INTERFACE = "org.mpris.MediaPlayer2"
+
+    IDENTITY = "Snapcast client"
+
+    # python dbus bindings don't include annotations and properties
+    MPRIS2_INTROSPECTION = """<node name="/org/mpris/MediaPlayer2">
+      <interface name="org.freedesktop.DBus.Introspectable">
+        <method name="Introspect">
+          <arg direction="out" name="xml_data" type="s"/>
+        </method>
+      </interface>
+      <interface name="org.freedesktop.DBus.Properties">
+        <method name="Get">
+          <arg direction="in" name="interface_name" type="s"/>
+          <arg direction="in" name="property_name" type="s"/>
+          <arg direction="out" name="value" type="v"/>
+        </method>
+        <method name="GetAll">
+          <arg direction="in" name="interface_name" type="s"/>
+          <arg direction="out" name="properties" type="a{sv}"/>
+        </method>
+        <method name="Set">
+          <arg direction="in" name="interface_name" type="s"/>
+          <arg direction="in" name="property_name" type="s"/>
+          <arg direction="in" name="value" type="v"/>
+        </method>
+        <signal name="PropertiesChanged">
+          <arg name="interface_name" type="s"/>
+          <arg name="changed_properties" type="a{sv}"/>
+          <arg name="invalidated_properties" type="as"/>
+        </signal>
+      </interface>
+      <interface name="org.mpris.MediaPlayer2">
+        <method name="Raise"/>
+        <method name="Quit"/>
+        <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+        <property name="CanQuit" type="b" access="read"/>
+        <property name="CanRaise" type="b" access="read"/>
+        <property name="HasTrackList" type="b" access="read"/>
+        <property name="Identity" type="s" access="read"/>
+        <property name="DesktopEntry" type="s" access="read"/>
+        <property name="SupportedUriSchemes" type="as" access="read"/>
+        <property name="SupportedMimeTypes" type="as" access="read"/>
+      </interface>
+      <interface name="org.mpris.MediaPlayer2.Player">
+        <method name="Next"/>
+        <method name="Previous"/>
+        <method name="Pause"/>
+        <method name="PlayPause"/>
+        <method name="Stop"/>
+        <method name="Play"/>
+        <method name="Seek">
+          <arg direction="in" name="Offset" type="x"/>
+        </method>
+        <method name="SetPosition">
+          <arg direction="in" name="TrackId" type="o"/>
+          <arg direction="in" name="Position" type="x"/>
+        </method>
+        <method name="OpenUri">
+          <arg direction="in" name="Uri" type="s"/>
+        </method>
+        <signal name="Seeked">
+          <arg name="Position" type="x"/>
+        </signal>
+        <property name="PlaybackStatus" type="s" access="read">
+          <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
+        </property>
+        <property name="LoopStatus" type="s" access="readwrite">
+          <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
+        </property>
+        <property name="Rate" type="d" access="readwrite">
+          <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
+        </property>
+        <property name="Shuffle" type="b" access="readwrite">
+          <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
+        </property>
+        <property name="Metadata" type="a{sv}" access="read">
+          <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
+        </property>
+        <property name="Volume" type="d" access="readwrite">
+          <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+        </property>
+        <property name="Position" type="x" access="read">
+          <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+        </property>
+        <property name="MinimumRate" type="d" access="read">
+          <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
+        </property>
+        <property name="MaximumRate" type="d" access="read">
+          <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
+        </property>
+        <property name="CanGoNext" type="b" access="read">
+          <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
+        </property>
+        <property name="CanGoPrevious" type="b" access="read">
+          <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
+        </property>
+        <property name="CanPlay" type="b" access="read">
+          <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
+        </property>
+        <property name="CanPause" type="b" access="read">
+          <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
+        </property>
+        <property name="CanSeek" type="b" access="read">
+          <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
+        </property>
+        <property name="CanControl" type="b" access="read">
+          <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+        </property>
+      </interface>
+    </node>"""
+
+    def __init__(self, wrapper_instance, glib_loop):
+        dbus.service.Object.__init__(self, dbus.SystemBus(),
+                                     SnapcastMPRISInterface.PATH)
+        self.name = "org.mpris.MediaPlayer2.snapcast"
+        self.wrapper_instance = wrapper_instance
+        self.glib_loop = glib_loop
+        self.bus = dbus.SystemBus()
+        self.uname = self.bus.get_unique_name()
+        self.dbus_obj = self.bus.get_object("org.freedesktop.DBus",
+                                            "/org/freedesktop/DBus")
+        self.dbus_obj.connect_to_signal("NameOwnerChanged",
+                                        self.name_owner_changed_callback,
+                                        arg0=self.name)
+
+        self.bus_name = self.acquire_name()
+        logging.info("name on DBus aqcuired")
+
+    def name_owner_changed_callback(self, name, old_owner, new_owner):
+        if name == self.name and old_owner == self.uname and new_owner != "":
+            try:
+                pid = self._dbus_obj.GetConnectionUnixProcessID(new_owner)
+            except:
+                pid = None
+            logging.info("Replaced by %s (PID %s)" %
+                         (new_owner, pid or "unknown"))
+            self.glib_loop.quit()
+
+    def acquire_name(self):
+        return dbus.service.BusName(self.name,
+                                    bus=self.bus,
+                                    allow_replacement=True,
+                                    replace_existing=True)
+
+    def release_name(self):
+        if hasattr(self, "_bus_name"):
+            del self.bus_name
+
+    @dbus.service.method(INTROSPECT_INTERFACE)
+    def Introspect(self):
+        return SnapcastMPRISInterface.MPRIS2_INTROSPECTION
+
+    def get_metadata(self):
+        return dbus.Dictionary(self.wrapper_instance.metadata, signature='sv')
+
+    def get_dbus_playback_status(self):
+        status = self.wrapper_instance.playback_status
+        return {SnapcastWrapper.PLAYBACK_PLAYING: 'Playing',
+                SnapcastWrapper.PLAYBACK_PAUSED: 'Paused',
+                SnapcastWrapper.PLAYBACK_STOPPED: 'Stopped',
+                SnapcastWrapper.PLAYBACK_UNKNOWN: 'Unknown'}[status]
+
+    def get_prop_mapping(self):
+        player_props = {
+            "PlaybackStatus": (self.get_dbus_playback_status, None),
+            "Rate": (1.0, None),
+            "Metadata": (self.get_metadata, None),
+            "MinimumRate": (1.0, None),
+            "MaximumRate": (1.0, None),
+            "CanGoNext": (False, None),
+            "CanGoPrevious": (False, None),
+            "CanPlay": (True, None),
+            "CanPause": (True, None),
+            "CanSeek": (False, None),
+            "CanControl": (False, None),
+        }
+
+        root_props = {
+            "CanQuit": (False, None),
+            "CanRaise": (False, None),
+            "DesktopEntry": ("snapcastmpris", None),
+            "HasTrackList": (False, None),
+            "Identity": (SnapcastMPRISInterface.IDENTITY, None),
+            "SupportedUriSchemes": (dbus.Array(signature="s"), None),
+            "SupportedMimeTypes": (dbus.Array(signature="s"), None)
+        }
+
+        return {
+            SnapcastMPRISInterface.PLAYER_INTERFACE: player_props,
+            SnapcastMPRISInterface.ROOT_INTERFACE: root_props,
+        }
+
+    @dbus.service.signal(PROP_INTERFACE, signature="sa{sv}as")
+    def PropertiesChanged(self, interface, changed_properties,
+                          invalidated_properties):
+        pass
+
+    @dbus.service.method(PROP_INTERFACE,
+                         in_signature="ss", out_signature="v")
+    def Get(self, interface, prop):
+        getter, _setter = self.PROP_MAPPING[interface][prop]
+        if callable(getter):
+            return getter()
+        return getter
+
+    @dbus.service.method(PROP_INTERFACE,
+                         in_signature="ssv", out_signature="")
+    def Set(self, interface, prop, value):
+        _getter, setter = self.PROP_MAPPING[interface][prop]
+        if setter is not None:
+            setter(value)
+
+    @dbus.service.method(PROP_INTERFACE,
+                         in_signature="s", out_signature="a{sv}")
+    def GetAll(self, interface):
+        read_props = {}
+        props = self.PROP_MAPPING[interface]
+        for key, (getter, _setter) in props.items():
+            if callable(getter):
+                getter = getter()
+            read_props[key] = getter
+        return read_props
+
+    def update_property(self, interface, prop):
+        getter, _setter = self.PROP_MAPPING[interface][prop]
+        if callable(getter):
+            value = getter()
+        else:
+            value = getter
+        logging.debug('Updated property: %s = %s' % (prop, value))
+        self.PropertiesChanged(interface, {prop: value}, [])
+        return value
+
+    # Player methods
+    @dbus.service.method(PLAYER_INTERFACE, in_signature='', out_signature='')
+    def Pause(self):
+        logging.debug("received DBUS pause")
+        self.wrapper_instance.pause_playback()
+        return
+
+    @dbus.service.method(PLAYER_INTERFACE, in_signature='', out_signature='')
+    def PlayPause(self):
+        logging.debug("received DBUS play/pause")
+        status = self.wrapper_instance.playback_status
+
+        if status == SnapcastWrapper.PLAYBACK_PLAYING:
+            self.wrapper_instance.pause_playback()
+        else:
+            self.wrapper_instance.start_playback()
+        return
+
+    @dbus.service.method(PLAYER_INTERFACE, in_signature='', out_signature='')
+    def Stop(self):
+        logging.debug("received DBUS stop")
+        self.wrapper_instance.stop_playback()
+        return
+
+    @dbus.service.method(PLAYER_INTERFACE, in_signature='', out_signature='')
+    def Play(self):
+        self.wrapper_instance.start_playback()
+        return

--- a/SnapcastMPRISInterface.py
+++ b/SnapcastMPRISInterface.py
@@ -191,7 +191,7 @@ class SnapcastMPRISInterface(dbus.service.Object):
             "CanPlay": (True, None),
             "CanPause": (True, None),
             "CanSeek": (False, None),
-            "CanControl": (False, None),
+            "CanControl": (True, None),
         }
 
         root_props = {

--- a/SnapcastRpcListener.py
+++ b/SnapcastRpcListener.py
@@ -1,0 +1,15 @@
+class SnapcastRpcListener:
+    def on_snapserver_stream_pause(self):
+        pass
+
+    def on_snapserver_stream_start(self, stream_name):
+        pass
+
+    def on_snapserver_volume_change(self, volume_level):
+        pass
+
+    def on_snapserver_mute(self):
+        pass
+
+    def on_snapserver_unmute(self):
+        pass

--- a/SnapcastRpcListener.py
+++ b/SnapcastRpcListener.py
@@ -2,7 +2,7 @@ class SnapcastRpcListener:
     def on_snapserver_stream_pause(self):
         pass
 
-    def on_snapserver_stream_start(self, stream_name):
+    def on_snapserver_stream_start(self, stream_name, stream_group):
         pass
 
     def on_snapserver_volume_change(self, volume_level):

--- a/SnapcastRpcWebsocketWrapper.py
+++ b/SnapcastRpcWebsocketWrapper.py
@@ -14,13 +14,13 @@ RPC_EVENT_STREAM_UPDATE = "Stream.OnUpdate"
 
 class SnapcastRpcWebsocketWrapper:
 
-    def __init__(self, server_ip: str, listener: SnapcastRpcListener):
+    def __init__(self, server_address: str, listener: SnapcastRpcListener):
         self.healthy = True
-        self.server_ip = server_ip
+        self.server_address = server_address
         self.client_id = SnapcastRpcWrapper.get_client_id()
         self.listener = listener
         self.websocket = websocket.WebSocketApp(
-            "ws://" + server_ip + ":1780/jsonrpc",
+            "ws://" + server_address + ":1780/jsonrpc",
             on_message=self.on_ws_message,
             on_error=self.on_ws_error,
             on_close=self.on_ws_close,
@@ -90,7 +90,7 @@ class SnapcastRpcWebsocketWrapper:
 
         # TODO: we need to know/check if the stream is played on this client
         # It might only be targeted at other players, in which case this player shouldn't do anything
-
+        stream_group = ""
         stream_status = params["stream"]["status"]
         # The stream name can be present in id, stream.id, or stream.meta.STREAM
         if "meta" in params["stream"]:
@@ -100,7 +100,7 @@ class SnapcastRpcWebsocketWrapper:
 
         if stream_status == "playing":
             logging.info("Snapclient stream started")
-            self.listener.on_snapserver_stream_start(stream_name)
+            self.listener.on_snapserver_stream_start(stream_name, stream_group)
         elif stream_status == "idle":
             logging.info("Snapclient stream idle")
             self.listener.on_snapserver_stream_pause()

--- a/SnapcastRpcWebsocketWrapper.py
+++ b/SnapcastRpcWebsocketWrapper.py
@@ -1,0 +1,126 @@
+import json
+import logging
+import threading
+import websocket
+from SnapcastRpcWrapper import SnapcastRpcWrapper
+from SnapcastRpcListener import SnapcastRpcListener
+
+RPC_EVENT_CLIENT_VOLUME_CHANGE = "Client.OnVolumeChanged"
+RPC_EVENT_CLIENT_MUTE = "Client.OnMute"
+RPC_EVENT_CLIENT_CONNECT = "Client.OnConnect"
+RPC_EVENT_CLIENT_DISCONNECT = "Client.OnDisconnect"
+RPC_EVENT_STREAM_UPDATE = "Stream.OnUpdate"
+
+
+class SnapcastRpcWebsocketWrapper:
+
+    def __init__(self, server_ip: str, listener: SnapcastRpcListener):
+        self.healthy = True
+        self.server_ip = server_ip
+        self.client_id = SnapcastRpcWrapper.get_client_id()
+        self.listener = listener
+        self.websocket = websocket.WebSocketApp(
+            "ws://" + server_ip + ":1780/jsonrpc",
+            on_message=self.on_ws_message,
+            on_error=self.on_ws_error,
+            on_close=self.on_ws_close,
+        )
+        self.websocket_thread = threading.Thread(target=self.websocket_loop, args=())
+        self.websocket_thread.name = "SnapcastRpcWebsocketWrapper"
+        self.websocket_thread.start()
+
+    def websocket_loop(self):
+        logging.info("Started SnapcastRpcWebsocketWrapper loop")
+        self.websocket.run_forever()
+        logging.info("Ending SnapcastRpcWebsocketWrapper loop")
+
+    def on_ws_message(self, message):
+        logging.debug("Snapcast RPC websocket message received")
+        logging.debug(message)
+        json_data = json.loads(message)
+
+        handlers = self.get_event_handlers_mapping()
+
+        event = json_data["method"]
+        handlers[event](json_data["params"])
+
+    def get_event_handlers_mapping(self):
+        return {
+            RPC_EVENT_CLIENT_VOLUME_CHANGE: self.on_volume_change,
+            RPC_EVENT_CLIENT_MUTE: self.on_mute,
+            RPC_EVENT_CLIENT_CONNECT: self.on_client_connect,
+            RPC_EVENT_CLIENT_DISCONNECT: self.on_client_disconnect,
+            RPC_EVENT_STREAM_UPDATE: self.on_stream_update,
+        }
+
+    def on_volume_change(self, params: {}):
+        if not self.targeted_at_current_client(params):
+            return
+        volume = params['volume']['percent']
+        logging.info("Snapclient volume changed to " + str(volume))
+        self.listener.on_snapserver_volume_change(volume)
+
+    def on_mute(self, params: {}):
+        if not self.targeted_at_current_client(params):
+            return
+        is_muted = params['mute']
+        if is_muted:
+            logging.info("Snapclient muted")
+            self.listener.on_snapserver_mute()
+        else:
+            logging.info("Snapclient unmuted")
+            self.listener.on_snapserver_unmute()
+
+    def on_client_connect(self, params: {}):
+        if not self.targeted_at_current_client(params):
+            return
+        # Not used right now, but could be useful for status monitoring
+        # This event is fired every second for every connected client
+        logging.debug("Client connected!")
+
+    def on_client_disconnect(self, params: {}):
+        if not self.targeted_at_current_client(params):
+            return
+        # Not used right now, but could be useful for status monitoring
+        logging.info("Client disconnected!")
+
+    def on_stream_update(self, params: {}):
+        # There is a lot of information here, such as audio details
+        # We focus on idle/playing right now
+
+        # TODO: we need to know/check if the stream is played on this client
+        # It might only be targeted at other players, in which case this player shouldn't do anything
+
+        stream_status = params["stream"]["status"]
+        # The stream name can be present in id, stream.id, or stream.meta.STREAM
+        if "meta" in params["stream"]:
+            stream_name = params["stream"]["meta"]["STREAM"]
+        else:
+            stream_name = params["stream"]["id"]
+
+        if stream_status == "playing":
+            logging.info("Snapclient stream started")
+            self.listener.on_snapserver_stream_start(stream_name)
+        elif stream_status == "idle":
+            logging.info("Snapclient stream idle")
+            self.listener.on_snapserver_stream_pause()
+        else:
+            logging.warning("Snapclient stream has unknown status: " + stream_status)
+
+    def targeted_at_current_client(self, params: {}):
+        # This method works only for client-specific events!
+        return params["id"] == self.client_id
+
+    # noinspection PyMethodMayBeStatic
+    def on_ws_error(self, error):
+        logging.error("Snapcast RPC websocket error")
+        logging.error(error)
+
+    def on_ws_close(self):
+        logging.info("Snapcast RPC websocket closed!")
+        self.healthy = False
+
+    def stop(self):
+        self.websocket.keep_running = False
+        logging.info("Waiting for websocket thread to exit")
+        self.websocket_thread.join()

--- a/SnapcastRpcWrapper.py
+++ b/SnapcastRpcWrapper.py
@@ -34,7 +34,7 @@ class SnapcastRpcWrapper:
              "jsonrpc": "2.0",
              "method": "Server.GetStatus",
              }
-        return self.call_snapserver_jsonrcp(payload)
+        return self.call_snapserver_jsonrcp(payload)["params"]
 
     def get_status(self):
         logging.info("Getting snapclient status")
@@ -44,7 +44,7 @@ class SnapcastRpcWrapper:
              "method": "Client.GetStatus",
              "params": {"id": self.client_id}
              }
-        return self.call_snapserver_jsonrcp(payload)
+        return self.call_snapserver_jsonrcp(payload)["params"]
 
     def unmute(self):
         logging.info("Unmuting snapclient")

--- a/SnapcastRpcWrapper.py
+++ b/SnapcastRpcWrapper.py
@@ -55,7 +55,7 @@ class SnapcastRpcWrapper:
         self.set_muted(True)
 
     def set_muted(self, is_muted):
-        logging.info("Setting snapclient mute to " + str(is_muted))
+        logging.debug("Setting snapclient mute to " + str(is_muted))
         payload = \
             {"id": REQ_TAG_SET_MUTE,
              "jsonrpc": "2.0",

--- a/SnapcastRpcWrapper.py
+++ b/SnapcastRpcWrapper.py
@@ -1,0 +1,140 @@
+import json
+from os import listdir
+import logging
+import requests
+
+REQ_TAG_GET_SERVER_RPC_VERSION = 0
+REQ_TAG_SET_VOLUME = 1
+REQ_TAG_SET_MUTE = 2
+REQ_TAG_SET_NAME = 3
+REQ_TAG_SET_LATENCY = 4
+REQ_TAG_GET_STATUS = 5
+REQ_TAG_GET_SERVER_STATUS = 6
+
+
+class SnapcastRpcWrapper:
+
+    def __init__(self, server_ip):
+        """
+        Create a new instance
+
+        :param:server_ip The ip of the snapcast server
+        :param:listener a SnapcastRpcListener listener
+        """
+        logging.debug("Initializing SnapcastRpcWrapper")
+        self.server_ip = server_ip
+        self.client_id = SnapcastRpcWrapper.get_client_id()
+        self.verify_srver_rpc_version()
+        logging.debug("Initialized SnapcastRpcWrapper")
+
+    def get_server_status(self):
+        logging.info("Getting snapserver clients")
+        payload = \
+            {"id": REQ_TAG_GET_SERVER_STATUS,
+             "jsonrpc": "2.0",
+             "method": "Server.GetStatus",
+             }
+        return self.call_snapserver_jsonrcp(payload)
+
+    def get_status(self):
+        logging.info("Getting snapclient status")
+        payload = \
+            {"id": REQ_TAG_GET_STATUS,
+             "jsonrpc": "2.0",
+             "method": "Client.GetStatus",
+             "params": {"id": self.client_id}
+             }
+        return self.call_snapserver_jsonrcp(payload)
+
+    def unmute(self):
+        logging.info("Unmuting snapclient")
+        self.set_muted(False)
+
+    def mute(self):
+        logging.info("Muting snapclient")
+        self.set_muted(True)
+
+    def set_muted(self, is_muted):
+        logging.info("Setting snapclient mute to " + str(is_muted))
+        payload = \
+            {"id": REQ_TAG_SET_MUTE,
+             "jsonrpc": "2.0",
+             "method": "Client.SetVolume",
+             "params":
+                 {"id": self.client_id,
+                  "volume": {"muted": is_muted}}}
+        self.call_snapserver_jsonrcp(payload)
+
+    def set_volume(self, volume_level):
+        logging.info("Setting snapclient volume level to " + volume_level)
+        volume_level = min(volume_level, 100)
+        volume_level = max(volume_level, 0)
+        payload = \
+            {"id": REQ_TAG_SET_VOLUME,
+             "jsonrpc": "2.0",
+             "method": "Client.SetVolume",
+             "params":
+                 {"id": self.client_id,
+                  "volume": {"volume": volume_level}}}
+        self.call_snapserver_jsonrcp(payload)
+
+    def set_name(self, name):
+        logging.info("Setting snapclient name to " + name)
+        payload = \
+            {"id": REQ_TAG_SET_NAME,
+             "jsonrpc": "2.0",
+             "method": "Client.SetName",
+             "params": {"id": self.client_id,
+                        "name": name}
+             }
+        self.call_snapserver_jsonrcp(payload)
+
+    def set_latency(self, latency):
+        logging.info("Setting snapclient latency to " + latency)
+        payload = \
+            {"id": REQ_TAG_SET_LATENCY,
+             "jsonrpc": "2.0",
+             "method": "Client.SetName",
+             "params": {"id": self.client_id,
+                        "latency": latency}
+             }
+        self.call_snapserver_jsonrcp(payload)
+
+    def verify_srver_rpc_version(self):
+        payload = {"id": REQ_TAG_GET_SERVER_RPC_VERSION,
+                   "jsonrpc": "2.0",
+                   "method": "Server.GetRPCVersion"}
+        result = self.call_snapserver_jsonrcp(payload)
+        # Result: {"major":2,"minor":0,"patch":0}
+        logging.info(f"Snapserver RPC version is {result['major']}.{result['minor']}.{result['major']}")
+        if result['major'] != 2:
+            logging.warning("Snapserver uses a JsonRPC version different from v2")
+            logging.warning("Snapserver RPC calls might cause unexpected behaviour")
+            logging.warning("Update Snapserver to resolve this")
+
+    def call_snapserver_jsonrcp(self, payload_data):
+        logging.debug("Sending JsonRPC call to Snapserver at " + self.server_ip)
+        response = requests.post('http://' + self.server_ip + ":1780/jsonrpc", json=payload_data)
+        logging.debug("JsonRCP response: " + response.text)
+        return response.json()['result']
+
+    @staticmethod
+    def get_client_id():
+        # TODO: what if there is more than one active interface?
+        logging.info("Finding MAC address of active interface to use as snapclient id")
+        for interface in listdir("/sys/class/net/"):
+            if interface == "lo":
+                continue
+            try:
+                status = open('/sys/class/net/' + interface + '/operstate').readline()
+                logging.info(f"Status for interface {interface}: {status.strip()}")
+                if status == "down":
+                    continue
+                mac = open('/sys/class/net/' + interface + '/address').readline()
+                logging.info(f"MAC address for interface {interface}: {mac[0:17]}")
+                return mac[0:17]
+            except:
+                pass
+
+        logging.critical("Failed to find MAC address of active network adapter")
+        exit(1)

--- a/SnapcastRpcWrapper.py
+++ b/SnapcastRpcWrapper.py
@@ -14,15 +14,15 @@ REQ_TAG_GET_SERVER_STATUS = 6
 
 class SnapcastRpcWrapper:
 
-    def __init__(self, server_ip):
+    def __init__(self, server_address):
         """
         Create a new instance
 
-        :param:server_ip The ip of the snapcast server
+        :param:server_address The ip of the snapcast server
         :param:listener a SnapcastRpcListener listener
         """
         logging.debug("Initializing SnapcastRpcWrapper")
-        self.server_ip = server_ip
+        self.server_address = server_address
         self.client_id = SnapcastRpcWrapper.get_client_id()
         self.verify_srver_rpc_version()
         logging.debug("Initialized SnapcastRpcWrapper")
@@ -113,8 +113,8 @@ class SnapcastRpcWrapper:
             logging.warning("Update Snapserver to resolve this")
 
     def call_snapserver_jsonrcp(self, payload_data):
-        logging.debug("Sending JsonRPC call to Snapserver at " + self.server_ip)
-        response = requests.post('http://' + self.server_ip + ":1780/jsonrpc", json=payload_data)
+        logging.debug("Sending JsonRPC call to Snapserver at " + self.server_address)
+        response = requests.post('http://' + self.server_address + ":1780/jsonrpc", json=payload_data)
         logging.debug("JsonRCP response: " + response.text)
         return response.json()['result']
 

--- a/SnapcastWrapper.py
+++ b/SnapcastWrapper.py
@@ -1,0 +1,143 @@
+import sys
+import logging
+import time
+import threading
+import fcntl
+import os
+import subprocess
+import json
+import SnapcastMPRISInterface
+
+
+class SnapcastWrapper(threading.Thread):
+    """ Wrapper to handle snapcastclient
+    """
+    PLAYBACK_STOPPED = "stopped"
+    PLAYBACK_PAUSED = "pause"
+    PLAYBACK_PLAYING = "playing"
+    PLAYBACK_UNKNOWN = "unkown"
+
+    def __init__(self, glib_loop, server_ip):
+        super().__init__()
+        self.glib_loop = glib_loop
+        self.playerid = None
+        self.playback_status = "stopped"
+        self.metadata = {}
+        self.server_ip = server_ip
+
+        self.dbus_service = None
+
+        self.bus = dbus.SessionBus()
+        self.received_data = False
+
+        self.snapcastclient = None
+        self.streamname = ""
+
+    def run(self):
+        try:
+            self.dbus_service = SnapcastMPRISInterface(self, self.glib_loop)
+            self.mainloop()
+        except Exception as e:
+            logging.error("Snapcastwrapper thread exception: %s", e)
+            sys.exit(1)
+
+        logging.error("Snapcastwrapper thread died - this should not happen")
+        sys.exit(1)
+
+    def stop_playback(self):
+        self.playback_status = SnapcastWrapper.PLAYBACK_STOPPED
+
+    def start_playback(self):
+        self.playback_status = SnapcastWrapper.PLAYBACK_PLAYING
+
+    def mainloop(self):
+        current_playback_status = None
+        while True:
+            if self.playback_status != current_playback_status:
+                current_playback_status = self.playback_status
+
+                # Changed - do something
+                if self.playback_status == PLAYBACK_PLAYING:
+                    if self.snapcastclient is None:
+                        logging.info("pausing other players")
+                        subprocess.run(["/opt/hifiberry/bin/pause-all", "snapcast"])
+                        logging.info("starting snapcastclient")
+                        if self.server_ip is not None:
+                            serveroption = "-h " + self.server_ip
+                        else:
+                            serveroption = ""
+                        self.snapcastclient = \
+                            subprocess.Popen("/bin/snapclient -e {}".format(serveroption),
+                                             stdout=subprocess.PIPE,
+                                             stderr=subprocess.PIPE,
+                                             shell=True)
+                        logging.info("snapcastclient now running in background")
+
+                    else:
+                        logging.error("snapcast process seems to be running already")
+
+                else:
+                    # Not playing: kill client
+                    if self.snapcastclient is None:
+                        logging.info("No snapcast client running, doing nothing")
+                    else:
+                        logging.info("Killing snapcast client, doing nothing")
+                        self.snapcastclient.kill()
+                        # Wait until it died
+                        _outs, _errs = self.snapcastclient.communicate()
+                        self.snapcastclient = None
+
+                # Playback status has changed, now inform DBUS
+                self.update_metadata()
+                self.dbus_service.update_property('org.mpris.MediaPlayer2.Player',
+                                                  'PlaybackStatus')
+
+            # Check if snapcast is still running
+            if self.snapcastclient:
+                if self.snapcastclient.poll() is not None:
+                    logging.warning("snapclient died")
+                    self.playback_status = PLAYBACK_STOPPED
+                    self.snapcastclient = None
+
+            if self.snapcastclient:
+                stdout = non_block_read(self.snapcastclient.stdout)
+                if stdout:
+                    logging.debug("stdout: %s", stdout)
+
+                stderr = non_block_read(self.snapcastclient.stderr)
+                if stderr:
+                    self.parse_stderr(stderr)
+                    logging.info("stderr: %s", stderr)
+
+            time.sleep(0.2)
+
+    def parse_stderr(self, data):
+        updated = False
+        s = data.decode("utf-8")
+        for line in s.splitlines():
+            if line.startswith("metadata:"):
+                _attrib, mds = line.split(":", 1)
+                md = json.loads(mds)
+                if "STREAM" in md:
+                    self.streamname = md["STREAM"]
+                    updated = True
+
+        if updated:
+            self.update_metadata()
+
+    def update_metadata(self):
+        if self.snapcastclient is not None:
+            self.metadata["xesam:url"] = \
+                "snapcast://{}/{}".format(self.server, self.streamname)
+
+        self.dbus_service.update_property('org.mpris.MediaPlayer2.Player',
+                                          'Metadata')
+
+    def non_block_read(output):
+        fd = output.fileno()
+        fl = fcntl.fcntl(fd, fcntl.F_GETFL)
+        fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
+        try:
+            return output.read()
+        except:
+            return ""

--- a/SnapcastWrapper.py
+++ b/SnapcastWrapper.py
@@ -171,6 +171,7 @@ class SnapcastWrapper(threading.Thread, SnapcastRpcListener):
         if self.snapclient is not None:
             self.metadata["xesam:url"] = \
                 "snapcast://{}/{}".format(self.server_ip, self.stream_name)
+            self.metadata["xesam:title"] = self.stream_name
 
         self.dbus_service.update_property('org.mpris.MediaPlayer2.Player',
                                           'Metadata')

--- a/SnapcastWrapper.py
+++ b/SnapcastWrapper.py
@@ -157,9 +157,6 @@ class SnapcastWrapper(threading.Thread, SnapcastRpcListener):
 
     def on_snapserver_mute(self):
         self.playback_status = PLAYBACK_PAUSED
-        logging.info("Snapclient muted, reporting deactivation")
-        subprocess.run(["/opt/hifiberry/bin/report-deactivation",
-                        "playercontrol_player_snapcast"])
         pass
 
     def on_snapserver_unmute(self):

--- a/SnapcastWrapper.py
+++ b/SnapcastWrapper.py
@@ -60,11 +60,11 @@ class SnapcastWrapper(threading.Thread, SnapcastRpcListener):
 
     def start_playback(self):
         self.playback_status = PLAYBACK_PLAYING
+        self.pause_other_players()
         if self.snapclient is None:
-            self.pause_other_players()
             self.start_snapclient_process()
         else:
-            logging.error("snapcast process seems to be running already")
+            logging.info("snapcast process is already running")
         self.update_dbus()
         # Give snapclient a bit of time to register with the server
         time.sleep(0.5)
@@ -157,6 +157,7 @@ class SnapcastWrapper(threading.Thread, SnapcastRpcListener):
 
     def on_snapserver_mute(self):
         self.playback_status = PLAYBACK_PAUSED
+        logging.info("Snapclient muted, reporting deactivation")
         subprocess.run(["/opt/hifiberry/bin/report-deactivation",
                         "playercontrol_player_snapcast"])
         pass

--- a/readme.md
+++ b/readme.md
@@ -13,12 +13,13 @@ in a separate thread, is created.
 
 `SnapcastWrapper` has methods to start/pause/play snapcast audio, and keeps track of the _snapclient_ 
 process. It gets help from `SnapcastRpcWrapper`, which communicates with _snapserver_, the snapcast server.
-This communication with the _snapserver_ RPC API is used to control the snapcast audio level, mute status, client name.
-The `SnapcastRpcWebsocketWrapper` is used to receive events from the _snapserver_ RPC API. It receives information about
-the stream that is currently playing, such as the playing state and the name, and passes this on to the `SnapcastWrapper`.
-Volume level changes, muting of a client, client connects, disconnects, ... is handled by this websocket wrapper as well.
-`SnapcastMPRISInterface` is used to communicate through the DBUS, to receive play/pause/stop signals from the OS and to relay
-information about the current state back to the OS. 
+This communication with [the Snapserver RPC API](https://github.com/badaix/snapcast/blob/master/doc/json_rpc_api/v2_0_0.md)
+is used to control the snapcast audio level, mute status, client name. The `SnapcastRpcWebsocketWrapper` is used to receive 
+events from [the Snapserver RPC API](https://github.com/badaix/snapcast/blob/master/doc/json_rpc_api/v2_0_0.md). It receives 
+information about the stream that is currently playing, such as the playing state and the name, and passes this on to 
+the `SnapcastWrapper`. Volume level changes, muting of a client, client connects, disconnects, ... is handled by this 
+websocket wrapper as well. `SnapcastMPRISInterface` is used to communicate through the DBUS, to receive play/pause/stop 
+signals from the OS and to relay information about the current state back to the OS. 
 
 ## What SnapcastWrapper does
 SnapcastWrapper runs in a separate thread from the main script.
@@ -45,9 +46,10 @@ When stopping audio
 - SnapcastWrapper keeps running in order to act should a play signal come from DBUS or snapserver.
 
 ## What SnapcastRpcWrapper does
-SnapcastRpcWrapper is a helper class to SnapcastWrapper. It can mute and unmute the client, set the client volume, 
-change the client latency and change the client name. Through SnapcastRpcWrapper, the client information and server 
-information can be obtained.
+SnapcastRpcWrapper is a helper class to SnapcastWrapper, and provides access to 
+[the Snapserver RPC API](https://github.com/badaix/snapcast/blob/master/doc/json_rpc_api/v2_0_0.md). It can mute and 
+unmute the client, set the client volume, change the client latency and change the client name. Through
+SnapcastRpcWrapper, the client information and server information can be obtained.
 
 *The advantage of muting* is that snapserver can be configured not to send data to muted clients. This means that a 
 muted client will reduce network traffic, compared to a running process with ignored audio, or an audio level set to 0.

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,63 @@
+# Snapcast MPRIS wrapper
+
+([MPRIS: Media Player Remote Interfacing Specification](https://specifications.freedesktop.org/mpris-spec/2.2/))
+
+This project is a wrapper around the Snapclient binary and the Snapserver RPC API. 
+It exposes the current playing state on the desktop bus (D-BUS), and allows control 
+through the DBUS play/pause/stop signals. 
+
+## General working
+When the main script (`snapcastmpris.py`) is executed, it will hook into the communication 
+busses and set up and endless loop. An instance of `SnapcastWrapper`, which lives 
+in a separate thread, is created.
+
+`SnapcastWrapper` has methods to start/pause/play snapcast audio, and keeps track of the _snapclient_ 
+process. It gets help from `SnapcastRpcWrapper`, which communicates with _snapserver_, the snapcast server.
+This communication with the _snapserver_ RPC API is used to control the snapcast audio level, mute status, client name.
+The `SnapcastRpcWebsocketWrapper` is used to receive events from the _snapserver_ RPC API. It receives information about
+the stream that is currently playing, such as the playing state and the name, and passes this on to the `SnapcastWrapper`.
+Volume level changes, muting of a client, client connects, disconnects, ... is handled by this websocket wrapper as well.
+`SnapcastMPRISInterface` is used to communicate through the DBUS, to receive play/pause/stop signals from the OS and to relay
+information about the current state back to the OS. 
+
+## What SnapcastWrapper does
+SnapcastWrapper runs in a separate thread from the main script.
+SnapcastWrapper implements the SnapcastRpcListener class and methods, which are called by SnapcastRpcWebsocketWrapper.
+### Playing audio
+When playing audio
+- A Snapclient process is started 
+- Snapclient is unmuted through an RPC call
+- Other audio players are stopped (through the HifiBerryOS pause-all script)
+- DBUS status is updated
+
+### Pausing audio
+When pausing audio
+- Snapclient is muted through an RPC call
+- depending on the "pause" source, a flag in order to prevent snapclient to switch back to playing on the next stream update. 
+It will only switch back to playing automatically when the snapcast source stream has been paused.
+- Snapclient keeps running
+- DBUS status is updated
+
+### Stopping audio
+When stopping audio
+- The snapclient process is stopped
+- DBUS information is updated
+- SnapcastWrapper keeps running in order to act should a play signal come from DBUS or snapserver.
+
+## What SnapcastRpcWrapper does
+SnapcastRpcWrapper is a helper class to SnapcastWrapper. It can mute and unmute the client, set the client volume, 
+change the client latency and change the client name. Through SnapcastRpcWrapper, the client information and server 
+information can be obtained.
+
+*The advantage of muting* is that snapserver can be configured not to send data to muted clients. This means that a 
+muted client will reduce network traffic, compared to a running process with ignored audio, or an audio level set to 0.
+
+## What SnapcastRpcWebsocketWrapper does
+SnapcastRpcWebsocketWrapper runs a websocket in a separate thread, and calls callback methods in SnapcastWrapper (a SnapcastRpcListener 
+implementation) to act on stream and client status changes. 
+
+- When muted, the status is set to paused and a hook in SnapcastWrapper is called in order to de-activate the player in HifiberryOS.
+- When unmuted, nothing is done. If a stream is already playing to the active device, and the player is in PAUSED mode, 
+the player should switch to playing. This has not been implemented yet.
+- When a stream switches from idle to playing, and the previous pause event was not caused by a DBUS event, SnapcastWrapper switches to the playing state.
+- When a stream switches from playing to idle, the SnapcastWrapper pause logic is triggered to mute the client and switch to the PAUSED state.

--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,7 @@ muted client will reduce network traffic, compared to a running process with ign
 SnapcastRpcWebsocketWrapper runs a websocket in a separate thread, and calls callback methods in SnapcastWrapper (a SnapcastRpcListener 
 implementation) to act on stream and client status changes. 
 
-- When muted, the status is set to paused and a hook in SnapcastWrapper is called in order to de-activate the player in HifiberryOS.
+- When muted, the status is set to paused
 - When unmuted, nothing is done. If a stream is already playing to the active device, and the player is in PAUSED mode, 
 the player should switch to playing. This has not been implemented yet.
 - When a stream switches from idle to playing, and the previous pause event was not caused by a DBUS event, SnapcastWrapper switches to the playing state.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.*
 websocket-client>=0.57
+zeroconf>=0.28

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests==2.*
+websocket-client>=0.57

--- a/snapcastmpris.py
+++ b/snapcastmpris.py
@@ -76,7 +76,7 @@ def get_zeroconf_server_address():
     if service_info is None:
         logging.error("Failed to obtain snapserver address through zeroconf!")
         return None
-    logging.critical(service_info)
+    logging.debug(service_info)
     address = service_info.parsed_addresses(IPVersion.All)[0]
     logging.info("Obtained snapserver address through zeroconf: " + address)
     return address

--- a/snapcastmpris.py
+++ b/snapcastmpris.py
@@ -34,7 +34,7 @@ import time
 import signal
 import configparser
 from SnapcastWrapper import SnapcastWrapper
-from zeroconf import Zeroconf
+from zeroconf import Zeroconf, IPVersion
 
 import dbus.service
 from dbus.mainloop.glib import DBusGMainLoop
@@ -76,9 +76,10 @@ def get_zeroconf_server_address():
     if service_info is None:
         logging.error("Failed to obtain snapserver address through zeroconf!")
         return None
-    logging.info("Obtained snapserver address through zeroconf: " + service_info.server)
-    # Remove the trailing dot, as it is invalid in a host with port number
-    return service_info.server.rstrip(".")
+    logging.critical(service_info)
+    address = service_info.parsed_addresses(IPVersion.All)[0]
+    logging.info("Obtained snapserver address through zeroconf: " + address)
+    return address
 
 
 if __name__ == '__main__':

--- a/snapcastmpris.py
+++ b/snapcastmpris.py
@@ -31,13 +31,10 @@
 import sys
 import logging
 import time
-import threading
-import fcntl
-import os
-import subprocess
-import json
 import signal
 import configparser
+import SnapcastWrapper
+import SnapcastMPRISInterface
 
 import dbus.service
 from dbus.mainloop.glib import DBusGMainLoop
@@ -48,413 +45,12 @@ try:
 except ImportError:
     import glib as GLib
 
-identity = "Snapcast client"
-
-PLAYBACK_STOPPED = "stopped"
-PLAYBACK_PAUSED = "pause"
-PLAYBACK_PLAYING = "playing"
-PLAYBACK_UNKNOWN = "unkown"
-
-# python dbus bindings don't include annotations and properties
-MPRIS2_INTROSPECTION = """<node name="/org/mpris/MediaPlayer2">
-  <interface name="org.freedesktop.DBus.Introspectable">
-    <method name="Introspect">
-      <arg direction="out" name="xml_data" type="s"/>
-    </method>
-  </interface>
-  <interface name="org.freedesktop.DBus.Properties">
-    <method name="Get">
-      <arg direction="in" name="interface_name" type="s"/>
-      <arg direction="in" name="property_name" type="s"/>
-      <arg direction="out" name="value" type="v"/>
-    </method>
-    <method name="GetAll">
-      <arg direction="in" name="interface_name" type="s"/>
-      <arg direction="out" name="properties" type="a{sv}"/>
-    </method>
-    <method name="Set">
-      <arg direction="in" name="interface_name" type="s"/>
-      <arg direction="in" name="property_name" type="s"/>
-      <arg direction="in" name="value" type="v"/>
-    </method>
-    <signal name="PropertiesChanged">
-      <arg name="interface_name" type="s"/>
-      <arg name="changed_properties" type="a{sv}"/>
-      <arg name="invalidated_properties" type="as"/>
-    </signal>
-  </interface>
-  <interface name="org.mpris.MediaPlayer2">
-    <method name="Raise"/>
-    <method name="Quit"/>
-    <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    <property name="CanQuit" type="b" access="read"/>
-    <property name="CanRaise" type="b" access="read"/>
-    <property name="HasTrackList" type="b" access="read"/>
-    <property name="Identity" type="s" access="read"/>
-    <property name="DesktopEntry" type="s" access="read"/>
-    <property name="SupportedUriSchemes" type="as" access="read"/>
-    <property name="SupportedMimeTypes" type="as" access="read"/>
-  </interface>
-  <interface name="org.mpris.MediaPlayer2.Player">
-    <method name="Next"/>
-    <method name="Previous"/>
-    <method name="Pause"/>
-    <method name="PlayPause"/>
-    <method name="Stop"/>
-    <method name="Play"/>
-    <method name="Seek">
-      <arg direction="in" name="Offset" type="x"/>
-    </method>
-    <method name="SetPosition">
-      <arg direction="in" name="TrackId" type="o"/>
-      <arg direction="in" name="Position" type="x"/>
-    </method>
-    <method name="OpenUri">
-      <arg direction="in" name="Uri" type="s"/>
-    </method>
-    <signal name="Seeked">
-      <arg name="Position" type="x"/>
-    </signal>
-    <property name="PlaybackStatus" type="s" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
-    </property>
-    <property name="LoopStatus" type="s" access="readwrite">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
-    </property>
-    <property name="Rate" type="d" access="readwrite">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
-    </property>
-    <property name="Shuffle" type="b" access="readwrite">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
-    </property>
-    <property name="Metadata" type="a{sv}" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
-    </property>
-    <property name="Volume" type="d" access="readwrite">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-    <property name="Position" type="x" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-    <property name="MinimumRate" type="d" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
-    </property>
-    <property name="MaximumRate" type="d" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
-    </property>
-    <property name="CanGoNext" type="b" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
-    </property>
-    <property name="CanGoPrevious" type="b" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
-    </property>
-    <property name="CanPlay" type="b" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
-    </property>
-    <property name="CanPause" type="b" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
-    </property>
-    <property name="CanSeek" type="b" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
-    </property>
-    <property name="CanControl" type="b" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-  </interface>
-</node>"""
-
-
-def non_block_read(output):
-    fd = output.fileno()
-    fl = fcntl.fcntl(fd, fcntl.F_GETFL)
-    fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
-    try:
-        return output.read()
-    except:
-        return ""
-
-
-class SnapcastWrapper(threading.Thread):
-    """ Wrapper to handle snapcastclient
-    """
-
-    def __init__(self, snapcastserver):
-        super().__init__()
-        self.playerid = None
-        self.playback_status = "stopped"
-        self.metadata = {}
-        self.server = snapcastserver
-
-        self.dbus_service = None
-
-        self.bus = dbus.SessionBus()
-        self.received_data = False
-
-        self.snapcastclient = None
-        self.streamname = ""
-
-    def run(self):
-        try:
-            self.dbus_service = MPRISInterface()
-
-            self.mainloop()
-
-        except Exception as e:
-            logging.error("Snapcastwrapper thread exception: %s", e)
-            sys.exit(1)
-
-        logging.error("Snapcastwrapper thread died - this should not happen")
-        sys.exit(1)
-
-    def mainloop(self):
-        current_playback_status = None
-        while True:
-            if self.playback_status != current_playback_status:
-                current_playback_status = self.playback_status
-
-                # Changed - do something
-
-                if self.playback_status == PLAYBACK_PLAYING:
-                    if self.snapcastclient is None:
-                        logging.info("pausing other players")
-                        subprocess.run(["/opt/hifiberry/bin/pause-all", "snapcast"])
-                        logging.info("starting snapcastclient")
-                        if self.server is not None:
-                            serveroption = "-h " + self.server
-                        else:
-                            serveroption = ""
-                        self.snapcastclient = \
-                            subprocess.Popen("/bin/snapclient -e {}".format(serveroption),
-                                              stdout=subprocess.PIPE,
-                                              stderr=subprocess.PIPE,
-                                              shell=True)
-                        logging.info("snapcastclient now running in background")
-
-                    else:
-                        logging.error("snapcast process seems to be running already")
-
-                else:
-                    # Not playing: kill client
-                    if self.snapcastclient is None:
-                        logging.info("No snapcast client running, doing nothing")
-                    else:
-                        logging.info("Killing snapcast client, doing nothing")
-                        self.snapcastclient.kill()
-                        # Wait until it died
-                        _outs, _errs = self.snapcastclient.communicate()
-                        self.snapcastclient = None
-
-                # Playback status has changed, now inform DBUS
-                self.update_metadata()
-                self.dbus_service.update_property('org.mpris.MediaPlayer2.Player',
-                                                  'PlaybackStatus')
-
-            # Check if snapcast is still running
-            if self.snapcastclient:
-                if self.snapcastclient.poll() is not None:
-                    logging.warning("snapclient died")
-                    self.playback_status = PLAYBACK_STOPPED
-                    self.snapcastclient = None
-
-            if self.snapcastclient:
-                stdout = non_block_read(self.snapcastclient.stdout)
-                if stdout:
-                    logging.debug("stdout: %s", stdout)
-
-                stderr = non_block_read(self.snapcastclient.stderr)
-                if stderr:
-                    self.parse_stderr(stderr)
-                    logging.info("stderr: %s", stderr)
-
-            time.sleep(0.2)
-
-    def parse_stderr(self, data):
-        updated = False
-        s = data.decode("utf-8")
-        for line in s.splitlines():
-            if line.startswith("metadata:"):
-                _attrib, mds = line.split(":", 1)
-                md = json.loads(mds)
-                if "STREAM" in md:
-                    self.streamname = md["STREAM"]
-                    updated = True
-
-        if updated:
-            self.update_metadata()
-
-    def update_metadata(self):
-        if self.snapcastclient is not None:
-            self.metadata["xesam:url"] = \
-                "snapcast://{}/{}".format(self.server, self.streamname)
-
-        self.dbus_service.update_property('org.mpris.MediaPlayer2.Player',
-                                                  'Metadata')
-
-
-class MPRISInterface(dbus.service.Object):
-    ''' The base object of an MPRIS player '''
-
-    PATH = "/org/mpris/MediaPlayer2"
-    INTROSPECT_INTERFACE = "org.freedesktop.DBus.Introspectable"
-    PROP_INTERFACE = dbus.PROPERTIES_IFACE
-
-    def __init__(self):
-        dbus.service.Object.__init__(self, dbus.SystemBus(),
-                                     MPRISInterface.PATH)
-        self.name = "org.mpris.MediaPlayer2.snapcast"
-        self.bus = dbus.SystemBus()
-        self.uname = self.bus.get_unique_name()
-        self.dbus_obj = self.bus.get_object("org.freedesktop.DBus",
-                                            "/org/freedesktop/DBus")
-        self.dbus_obj.connect_to_signal("NameOwnerChanged",
-                                        self.name_owner_changed_callback,
-                                        arg0=self.name)
-
-        self.acquire_name()
-        logging.info("name on DBus aqcuired")
-
-    def name_owner_changed_callback(self, name, old_owner, new_owner):
-        if name == self.name and old_owner == self.uname and new_owner != "":
-            try:
-                pid = self._dbus_obj.GetConnectionUnixProcessID(new_owner)
-            except:
-                pid = None
-            logging.info("Replaced by %s (PID %s)" %
-                         (new_owner, pid or "unknown"))
-            loop.quit()
-
-    def acquire_name(self):
-        self.bus_name = dbus.service.BusName(self.name,
-                                             bus=self.bus,
-                                             allow_replacement=True,
-                                             replace_existing=True)
-
-    def release_name(self):
-        if hasattr(self, "_bus_name"):
-            del self.bus_name
-
-    ROOT_INTERFACE = "org.mpris.MediaPlayer2"
-    ROOT_PROPS = {
-        "CanQuit": (False, None),
-        "CanRaise": (False, None),
-        "DesktopEntry": ("snapcastmpris", None),
-        "HasTrackList": (False, None),
-        "Identity": (identity, None),
-        "SupportedUriSchemes": (dbus.Array(signature="s"), None),
-        "SupportedMimeTypes": (dbus.Array(signature="s"), None)
-    }
-
-    @dbus.service.method(INTROSPECT_INTERFACE)
-    def Introspect(self):
-        return MPRIS2_INTROSPECTION
-
-    def get_playback_status():
-        status = snapcast_wrapper.playback_status
-        return {PLAYBACK_PLAYING: 'Playing',
-                PLAYBACK_PAUSED: 'Paused',
-                PLAYBACK_STOPPED: 'Stopped',
-                PLAYBACK_UNKNOWN: 'Unknown'}[status]
-
-    def get_metadata():
-        return dbus.Dictionary(snapcast_wrapper.metadata, signature='sv')
-
-    PLAYER_INTERFACE = "org.mpris.MediaPlayer2.Player"
-    PLAYER_PROPS = {
-        "PlaybackStatus": (get_playback_status, None),
-        "Rate": (1.0, None),
-        "Metadata": (get_metadata, None),
-        "MinimumRate": (1.0, None),
-        "MaximumRate": (1.0, None),
-        "CanGoNext": (False, None),
-        "CanGoPrevious": (False, None),
-        "CanPlay": (True, None),
-        "CanPause": (True, None),
-        "CanSeek": (False, None),
-        "CanControl": (False, None),
-    }
-
-    PROP_MAPPING = {
-        PLAYER_INTERFACE: PLAYER_PROPS,
-        ROOT_INTERFACE: ROOT_PROPS,
-    }
-
-    @dbus.service.signal(PROP_INTERFACE, signature="sa{sv}as")
-    def PropertiesChanged(self, interface, changed_properties,
-                          invalidated_properties):
-        pass
-
-    @dbus.service.method(PROP_INTERFACE,
-                         in_signature="ss", out_signature="v")
-    def Get(self, interface, prop):
-        getter, _setter = self.PROP_MAPPING[interface][prop]
-        if callable(getter):
-            return getter()
-        return getter
-
-    @dbus.service.method(PROP_INTERFACE,
-                         in_signature="ssv", out_signature="")
-    def Set(self, interface, prop, value):
-        _getter, setter = self.PROP_MAPPING[interface][prop]
-        if setter is not None:
-            setter(value)
-
-    @dbus.service.method(PROP_INTERFACE,
-                         in_signature="s", out_signature="a{sv}")
-    def GetAll(self, interface):
-        read_props = {}
-        props = self.PROP_MAPPING[interface]
-        for key, (getter, _setter) in props.items():
-            if callable(getter):
-                getter = getter()
-            read_props[key] = getter
-        return read_props
-
-    def update_property(self, interface, prop):
-        getter, _setter = self.PROP_MAPPING[interface][prop]
-        if callable(getter):
-            value = getter()
-        else:
-            value = getter
-        logging.debug('Updated property: %s = %s' % (prop, value))
-        self.PropertiesChanged(interface, {prop: value}, [])
-        return value
-
-    # Player methods
-    @dbus.service.method(PLAYER_INTERFACE, in_signature='', out_signature='')
-    def Pause(self):
-        logging.debug("received DBUS pause")
-        snapcast_wrapper.playback_status = PLAYBACK_STOPPED
-        return
-
-    @dbus.service.method(PLAYER_INTERFACE, in_signature='', out_signature='')
-    def PlayPause(self):
-        logging.debug("received DBUS play/pause")
-        status = snapcast_wrapper.playback_status
-
-        if status == PLAYBACK_PLAYING:
-            snapcast_wrapper.playback_status = PLAYBACK_STOPPED
-        else:
-            snapcast_wrapper.playback_status = PLAYBACK_PLAYING
-        return
-
-    @dbus.service.method(PLAYER_INTERFACE, in_signature='', out_signature='')
-    def Stop(self):
-        logging.debug("received DBUS stop")
-        snapcast_wrapper.playback_status = PLAYBACK_STOPPED
-        return
-
-    @dbus.service.method(PLAYER_INTERFACE, in_signature='', out_signature='')
-    def Play(self):
-        snapcast_wrapper.playback_status = PLAYBACK_PLAYING
-        return
-
-
 def stopSnapcast(signalNumber, frame):
     logging.info("received USR1, stopping snapcast")
-    snapcast_wrapper.playback_status = PLAYBACK_STOPPED
+    snapcast_wrapper.stopPlayback()
 
 
-def parse_config(debugmode=False):
+def read_config():
     config = configparser.ConfigParser()
     try:
         with open("/etc/snapcastmpris.conf") as f:
@@ -464,15 +60,7 @@ def parse_config(debugmode=False):
         logging.info("can't read /etc/snapcastclient.conf, using default configurations")
         config = {"general": {}}
 
-    # Server to connect to
-    server = config.get("snapcast", "server")
-    snapcastWrapper = SnapcastWrapper(server)
-
-    # Auto start for snapcast
-    if config.getboolean("snapcast", "autostart", fallback=True):
-        snapcastWrapper.playback_status = PLAYBACK_PLAYING
-
-    return snapcastWrapper
+    return config
 
 
 if __name__ == '__main__':
@@ -488,15 +76,22 @@ if __name__ == '__main__':
                             level=logging.INFO)
 
     # Set up the main loop
-    loop = GLib.MainLoop()
-
+    glib_main_loop = GLib.MainLoop()
     signal.signal(signal.SIGUSR1, stopSnapcast)
-
-    server = "192.168.30.110"
 
     # Create wrapper to handle connection failures with MPD more gracefully
     try:
-        snapcast_wrapper = parse_config()
+        config = read_config()
+
+        # Server to connect to
+        server_address = config.get("snapcast", "server")
+        snapcast_wrapper = SnapcastWrapper(glib_main_loop, server_address)
+
+        # Auto start for snapcast
+        if config.getboolean("snapcast", "autostart", fallback=True):
+            snapcast_wrapper.startPlayback()
+
+        # Start the wrapper
         snapcast_wrapper.start()
         logging.info("Snapcast wrapper thread started")
     except dbus.exceptions.DBusException as e:


### PR DESCRIPTION
This PR adds support for obtaining and manipulating the snapclient state and configuration through the Snapserver RPC API. This means that snapcast now has the ability to automatically activate and deactivate based on the stream status. Pause is implemented through muting the client (in which case data flow to the client _can_ be stopped based on the server configuration). When stopped, a new process can be started when the server starts the audio stream. The whole project has been restructured into different files for each class to improve on readability and maintainability. 

Right now it works, but still seems to "fight" with the pause-all script which seems to contain a bug. Until it works 100%, this is a draft PR, but i figured you might be interested to know of this development and possibly want try it out.

**Known issues**
- In setups with different streams and groups, SnapcastWrapper might activate when a stream, which is not directed at this client, is activated.
- In setups where there are two or more *active* network links, RPC calls and event handling might not work since there would be multiple possible client-ids (which match the interface mac-address), without knowing which one to use.

**Known issues which should be fixed before merging**

- [x] In setups where the server IP/hostname is not defined, the SnapcastRPCWrapper cannot be initialized as it needs to know where to send the RPC calls. 