### PR TITLE
ALSA <-> Snapclient volume synchronisation

### DIFF
--- a/SnapcastRpcWebsocketWrapper.py
+++ b/SnapcastRpcWebsocketWrapper.py
@@ -64,7 +64,7 @@ class SnapcastRpcWebsocketWrapper:
         if volume == self.current_volume:
             logging.debug("Snapclient volume update, but no change: " + str(volume))
             return
-        logging.info("Snapclient volume changed to " + str(volume))
+        logging.debug("Snapclient volume changed to " + str(volume))
         self.listener.on_snapserver_volume_change(volume)
         self.current_volume = volume
 

--- a/SnapcastRpcWebsocketWrapper.py
+++ b/SnapcastRpcWebsocketWrapper.py
@@ -19,6 +19,9 @@ class SnapcastRpcWebsocketWrapper:
         self.server_address = server_address
         self.client_id = SnapcastRpcWrapper.get_client_id()
         self.listener = listener
+
+        self.current_volume = None
+
         self.websocket = websocket.WebSocketApp(
             "ws://" + server_address + ":1780/jsonrpc",
             on_message=self.on_ws_message,
@@ -57,8 +60,13 @@ class SnapcastRpcWebsocketWrapper:
         if not self.targeted_at_current_client(params):
             return
         volume = params['volume']['percent']
+        # Don't trigger multiple times on the same volume
+        if volume == self.current_volume:
+            logging.debug("Snapclient volume update, but no change: " + str(volume))
+            return
         logging.info("Snapclient volume changed to " + str(volume))
         self.listener.on_snapserver_volume_change(volume)
+        self.current_volume = volume
 
     def on_mute(self, params: {}):
         if not self.targeted_at_current_client(params):

--- a/SnapcastRpcWrapper.py
+++ b/SnapcastRpcWrapper.py
@@ -66,7 +66,7 @@ class SnapcastRpcWrapper:
         self.call_snapserver_jsonrcp(payload)
 
     def set_volume(self, volume_level):
-        logging.info("Setting snapclient volume level to " + volume_level)
+        logging.info("Setting snapclient volume level to " + str(volume_level))
         volume_level = min(volume_level, 100)
         volume_level = max(volume_level, 0)
         payload = \

--- a/SnapcastRpcWrapper.py
+++ b/SnapcastRpcWrapper.py
@@ -75,7 +75,7 @@ class SnapcastRpcWrapper:
              "method": "Client.SetVolume",
              "params":
                  {"id": self.client_id,
-                  "volume": {"volume": volume_level}}}
+                  "volume": {"percent": volume_level}}}
         self.call_snapserver_jsonrcp(payload)
 
     def set_name(self, name):

--- a/SnapcastWrapper.py
+++ b/SnapcastWrapper.py
@@ -205,7 +205,7 @@ class SnapcastWrapper(threading.Thread, SnapcastRpcListener):
                     logging.info("ALSA Volume changed - updating Snapserver")
                     self.on_system_volume_change(volume)
                     self.current_volume = volume
-        poll.unregister(descriptors)
+        poll.unregister(fd)
         logging.info("SnapcastWrapper ALSA volume poll thread exited")
 
     def set_system_volume(self, volume_level):

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,10 @@ signals from the OS and to relay information about the current state back to the
 ## What SnapcastWrapper does
 SnapcastWrapper runs in a separate thread from the main script.
 SnapcastWrapper implements the SnapcastRpcListener class and methods, which are called by SnapcastRpcWebsocketWrapper.
+When ALSA <=> Snapclient volume synchronisation is enabled, SnapcastWrapper will monitor the ALSA volume level and send
+any changes to Snapserver through SnapcastRPCWrapper. Volume synchronisation is disabled by default and enabled through 
+the `--sync-alsa-volume` flag. It requires the `alsaaudio` library to be installed.
+
 ### Playing audio
 When playing audio
 - A Snapclient process is started 
@@ -52,7 +56,7 @@ unmute the client, set the client volume, change the client latency and change t
 SnapcastRpcWrapper, the client information and server information can be obtained.
 
 *The advantage of muting* is that snapserver can be configured not to send data to muted clients. This means that a 
-muted client will reduce network traffic, compared to a running process with ignored audio, or an audio level set to 0.
+muted client will reduce network traffic, compared to a running process with ignored audio.
 
 ## What SnapcastRpcWebsocketWrapper does
 SnapcastRpcWebsocketWrapper runs a websocket in a separate thread, and calls callback methods in SnapcastWrapper (a SnapcastRpcListener 
@@ -63,3 +67,4 @@ implementation) to act on stream and client status changes.
 the player should switch to playing. This has not been implemented yet.
 - When a stream switches from idle to playing, and the previous pause event was not caused by a DBUS event, SnapcastWrapper switches to the playing state.
 - When a stream switches from playing to idle, the SnapcastWrapper pause logic is triggered to mute the client and switch to the PAUSED state.
+- When the snapclient volume level is changed, and ALSA <=> Snapclient volume synchronisation is enabled, the ALSA volume is adjusted.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests==2.*
 websocket-client>=0.57
 zeroconf>=0.28
-alsaaudio
+# alsaaudio is required when running with the --sync-alsa-volume flag.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.*
 websocket-client>=0.57
 zeroconf>=0.28
+alsaaudio

--- a/snapcastmpris.py
+++ b/snapcastmpris.py
@@ -120,7 +120,7 @@ if __name__ == '__main__':
             logging.critical("Snapcast cannot be launched: failed to obtain snapcast server address.")
             exit(1)
 
-        snapcast_wrapper = SnapcastWrapper(glib_main_loop, server_address)
+        snapcast_wrapper = SnapcastWrapper(glib_main_loop, server_address, sync_volume=True)
 
         # Auto start for snapcast
         if config.getboolean("snapcast", "autostart", fallback=True):


### PR DESCRIPTION
This feature adds the `--sync-alsa-volume` flag which will sync the OS volume with the snapcast volume, for those who want to use this the same way as spotify connect controls the OS volume. Volume synchronisation is disabled by default.