### PR TITLE
Add support for multiple active network interfaces, narrow down selection of Zeroconf address

### DIFF
--- a/SnapcastRpcWebsocketWrapper.py
+++ b/SnapcastRpcWebsocketWrapper.py
@@ -14,16 +14,17 @@ RPC_EVENT_STREAM_UPDATE = "Stream.OnUpdate"
 
 class SnapcastRpcWebsocketWrapper:
 
-    def __init__(self, server_address: str, listener: SnapcastRpcListener):
+    def __init__(self, server_address: str, server_control_port, client_id, listener: SnapcastRpcListener):
         self.healthy = True
         self.server_address = server_address
-        self.client_id = SnapcastRpcWrapper.get_client_id()
+        self.server_control_port = server_control_port
+        self.client_id = client_id
         self.listener = listener
 
         self.current_volume = None
 
         self.websocket = websocket.WebSocketApp(
-            "ws://" + server_address + ":1780/jsonrpc",
+            "ws://" + server_address + ":" + str(server_control_port) + "/jsonrpc",
             on_message=self.on_ws_message,
             on_error=self.on_ws_error,
             on_close=self.on_ws_close,

--- a/snapcastmpris.py
+++ b/snapcastmpris.py
@@ -75,14 +75,26 @@ def get_zeroconf_server_address():
     service_info = zerocfg.get_service_info("_snapcast._tcp.local.",
                                             "Snapcast._snapcast._tcp.local.",
                                             3000)
-    logging.info(service_info)
     if service_info is None:
         logging.error("Failed to obtain snapserver address through zeroconf!")
         return None
     logging.debug(service_info)
-    address = service_info.parsed_addresses(IPVersion.All)[0]
-    logging.info("Obtained snapserver address through zeroconf: " + address)
-    return address
+    snapserver_address = None
+    all_addresses = service_info.parsed_addresses(IPVersion.V4Only)
+    for address in all_addresses:
+        if address != "0.0.0.0":
+            snapserver_address = address
+    if snapserver_address is None:
+        logging.critical("Failed to obtain snapserver address through zeroconf, got 0.0.0.0 but expected real address!")
+        logging.error(service_info)
+        logging.error(all_addresses)
+        return None
+    if len(all_addresses) > 1:
+        logging.warning("Got more than one zeroconf address, what's happening here?!")
+        logging.warning(service_info)
+        logging.warning(all_addresses)
+    logging.info("Obtained snapserver address through zeroconf: " + snapserver_address)
+    return snapserver_address
 
 
 if __name__ == '__main__':

--- a/snapcastmpris.py
+++ b/snapcastmpris.py
@@ -72,7 +72,10 @@ def read_config():
 
 def get_zeroconf_server_address():
     zerocfg = Zeroconf()
-    service_info = zerocfg.get_service_info("_snapcast._tcp.local.", "Snapcast._snapcast._tcp.local.", 3000)
+    service_info = zerocfg.get_service_info("_snapcast._tcp.local.",
+                                            "Snapcast._snapcast._tcp.local.",
+                                            3000)
+    logging.info(service_info)
     if service_info is None:
         logging.error("Failed to obtain snapserver address through zeroconf!")
         return None


### PR DESCRIPTION
- Add support for multiple active network interfaces: the correct snapclient id will be determined based on the list of active clients received from the server in case there is more than one active network interface
- Get the port number for streaming through zeroconf, fallback to default port if zeroconf is unavailable
- Only obtain IPv4 addresses through zeroconf, v6 addresses aren't supported for HTTP requests anyway
- In case 0.0.0.0 is included as zeroconf address, skip it and print a warning including enough debug information. In case it's the only one, exit with debug information. This might resolve #3 in case it was caused by a condition that put 0.0.0.0 on top of the list. Since I currently can't reproduce the issue (through various reboots, upgrades, restarts, different (numbers of) network interfaces, devices, availability of snapserver, I cannot certainly say that it's fixed.