### PR TITLE
Fixing ws parameter issues

### DIFF
--- a/SnapcastRpcWebsocketWrapper.py
+++ b/SnapcastRpcWebsocketWrapper.py
@@ -38,7 +38,7 @@ class SnapcastRpcWebsocketWrapper:
         self.websocket.run_forever()
         logging.info("Ending SnapcastRpcWebsocketWrapper loop")
 
-    def on_ws_message(self, message):
+    def on_ws_message(self, object, message):
         logging.debug("Snapcast RPC websocket message received")
         logging.debug(message)
         json_data = json.loads(message)
@@ -121,11 +121,11 @@ class SnapcastRpcWebsocketWrapper:
         return params["id"] == self.client_id
 
     # noinspection PyMethodMayBeStatic
-    def on_ws_error(self, error):
+    def on_ws_error(self, object, error):
         logging.error("Snapcast RPC websocket error")
         logging.error(error)
 
-    def on_ws_close(self):
+    def on_ws_close(self, message):
         logging.info("Snapcast RPC websocket closed!")
         self.healthy = False
 

--- a/SnapcastWrapper.py
+++ b/SnapcastWrapper.py
@@ -47,8 +47,8 @@ class SnapcastWrapper(threading.Thread, SnapcastRpcListener):
         )
         self.websocket_wrapper = SnapcastRpcWebsocketWrapper(
             server_address,
-            self.rpc_wrapper.client_id,
             self.server_control_port,
+            self.rpc_wrapper.client_id,
             self
         )
 


### PR DESCRIPTION
Making sure that When creating the `SnapcastRpcWebsocketWrapper` the parameters for port and client id are sent in the correct order when created in `SnapcastWrapper`.

Adding correct parameter count to `on_ws_error`, `on_ws_close` and `on_ws_message`. This should fix hifiberry/snapcastmpris#8 abd hifiberry/snapcastmpris#9.