### PR TITLE
Fixes for extension_snapcast

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ websocket-client>=0.57
 zeroconf>=0.28
 pyalsaaudio
 dbus-python
-pygobject
+pygobject==3.50.0

--- a/snapcastmpris/SnapcastMPRISInterface.py
+++ b/snapcastmpris/SnapcastMPRISInterface.py
@@ -6,7 +6,7 @@ import subprocess
 import json
 import signal
 import dbus.service
-import snapcastmpris.SnapcastWrapper
+import SnapcastWrapper
 
 
 class SnapcastMPRISInterface(dbus.service.Object):

--- a/snapcastmpris/SnapcastRpcWebsocketWrapper.py
+++ b/snapcastmpris/SnapcastRpcWebsocketWrapper.py
@@ -2,8 +2,8 @@ import json
 import logging
 import threading
 import websocket
-from snapcastmpris.SnapcastRpcWrapper import SnapcastRpcWrapper
-from snapcastmpris.SnapcastRpcListener import SnapcastRpcListener
+from SnapcastRpcWrapper import SnapcastRpcWrapper
+from SnapcastRpcListener import SnapcastRpcListener
 
 RPC_EVENT_CLIENT_VOLUME_CHANGE = "Client.OnVolumeChanged"
 RPC_EVENT_CLIENT_MUTE = "Client.OnMute"

--- a/snapcastmpris/SnapcastWrapper.py
+++ b/snapcastmpris/SnapcastWrapper.py
@@ -114,7 +114,7 @@ class SnapcastWrapper(threading.Thread, SnapcastRpcListener):
 
     def start_snapclient_process(self):
         logging.info("starting Snapclient")
-        cmd = ["/bin/snapclient", "-e"]
+        cmd = ["snapclient", "-e"]
         if self.server_address is not None:
             cmd += ["-h", self.server_address]
         if self.server_streaming_port is not None:

--- a/snapcastmpris/SnapcastWrapper.py
+++ b/snapcastmpris/SnapcastWrapper.py
@@ -119,7 +119,7 @@ class SnapcastWrapper(threading.Thread, SnapcastRpcListener):
             cmd += ["-h", self.server_address]
         if self.server_streaming_port is not None:
             cmd += ["-p", str(self.server_streaming_port)]
-
+        logging.info("starting snapcast with command" + str(cmd))
         self.snapclient = \
             subprocess.Popen(" ".join(cmd),
                              stdout=subprocess.DEVNULL,

--- a/snapcastmpris/SnapcastWrapper.py
+++ b/snapcastmpris/SnapcastWrapper.py
@@ -5,10 +5,10 @@ import threading
 import subprocess
 import select
 from zeroconf import Zeroconf, IPVersion
-from snapcastmpris.SnapcastMPRISInterface import SnapcastMPRISInterface
-from snapcastmpris.SnapcastRpcListener import SnapcastRpcListener
-from snapcastmpris.SnapcastRpcWebsocketWrapper import SnapcastRpcWebsocketWrapper
-from snapcastmpris.SnapcastRpcWrapper import SnapcastRpcWrapper
+from SnapcastMPRISInterface import SnapcastMPRISInterface
+from SnapcastRpcListener import SnapcastRpcListener
+from SnapcastRpcWebsocketWrapper import SnapcastRpcWebsocketWrapper
+from SnapcastRpcWrapper import SnapcastRpcWrapper
 
 PLAYBACK_STOPPED = "stopped"
 PLAYBACK_PAUSED = "pause"

--- a/snapcastmpris/SnapcastWrapper.py
+++ b/snapcastmpris/SnapcastWrapper.py
@@ -114,7 +114,7 @@ class SnapcastWrapper(threading.Thread, SnapcastRpcListener):
 
     def start_snapclient_process(self):
         logging.info("starting Snapclient")
-        cmd = ["snapclient", "-e"]
+        cmd = ["snapclient"]
         if self.server_address is not None:
             cmd += ["-h", self.server_address]
         if self.server_streaming_port is not None:

--- a/snapcastmpris/snapcastmpris.py
+++ b/snapcastmpris/snapcastmpris.py
@@ -9,7 +9,7 @@ import signal
 import configparser
 import argparse
 
-from snapcastmpris.SnapcastWrapper import SnapcastWrapper
+from SnapcastWrapper import SnapcastWrapper
 from zeroconf import Zeroconf, IPVersion
 
 import dbus.service


### PR DESCRIPTION
This pull request contains two changes to allow the snapcast extension on HifiberryOS64 Alpha8 to work:

- fixed the import statements as the imported files are in the same folder and not in a subfolder.
- snapclient was being called from /bin/snapclient. The Dockerfile in extension_snapcast places the binary in /usr/local/bin. This change simply calls snapclient without a specific path reference.

I've tested these changes on Alpha 8 and got snapcast and snapcastmpris to work correctly (after some tweaking in the extension code and via SSH in HifiberryOS) by and building the docker container.